### PR TITLE
Improvements proposal

### DIFF
--- a/Gossip.Application/Handlers/Chat/DumpNewMessageToBlobStorage.cs
+++ b/Gossip.Application/Handlers/Chat/DumpNewMessageToBlobStorage.cs
@@ -16,7 +16,7 @@ namespace Gossip.Application.Handlers.Chat
 
         public void Handle(NewMessageCreatedEvent notification)
         {
-            _blobStorage.DoSomething(new Message { Content = notification.Content });
+            _blobStorage.DoSomething(new Message(notification.Content));
         }
     }
 }

--- a/Gossip.Application/Services/Chat/ChatService.cs
+++ b/Gossip.Application/Services/Chat/ChatService.cs
@@ -45,7 +45,7 @@ namespace Gossip.Application.Services.Chat
         public async Task<bool> AddMessage(Message message)
         {
             var channel = await _channelRepository.GetAsync(message.ChannelId);
-            channel.AddMessage(message.ParentId, message.Content);
+            channel.AddMessage(message.Content, message.ParentId);
             _channelRepository.UpdateChannel(channel);
             return await _channelRepository.UnitOfWork.SaveEntitiesAsync();
         }

--- a/Gossip.Domain.Tests/Chat/ChannelsTest.cs
+++ b/Gossip.Domain.Tests/Chat/ChannelsTest.cs
@@ -70,13 +70,12 @@ namespace Gossip.Domain.Tests.Chat
                 var mediator = scope.Resolve<IMediator>();
 
                 // Act
-                var channel = new Channel
+                var channel = new Channel("abc")
                 {
-                    Name = "abc",
                     Description = "def"
                 };
 
-                channel.AddMessage(null, "ghi");
+                channel.AddMessage("ghi");
                 await mediator.DispatchDomainEventsAsync(new List<Channel> { channel });
 
                 // Assert

--- a/Gossip.Domain/DomainMediatorExtension.cs
+++ b/Gossip.Domain/DomainMediatorExtension.cs
@@ -8,14 +8,14 @@ namespace Gossip.Domain
 {
     public static class DomainMediatorExtension
     {
-        public static async Task DispatchDomainEventsAsync(this IMediator mediator, IEnumerable<Entity> entities)
+        public static async Task DispatchDomainEventsAsync(this IMediator mediator, IEnumerable<AggregateRoot> entities)
         {
             var domainEvents = entities
                 .SelectMany(x => x.DomainEvents)
                 .ToList();
 
             entities.ToList()
-                .ForEach(entity => entity.DomainEvents.Clear());
+                .ForEach(entity => entity.ClearEvents());
 
             var tasks = domainEvents
                 .Select(async (domainEvent) => {

--- a/Gossip.Domain/Gossip.Domain.csproj
+++ b/Gossip.Domain/Gossip.Domain.csproj
@@ -1,11 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="MediatR" Version="3.0.1" />
   </ItemGroup>
-
 </Project>

--- a/Gossip.Domain/Models/AggregateRoot.cs
+++ b/Gossip.Domain/Models/AggregateRoot.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using MediatR;
+
+namespace Gossip.Domain.Models
+{
+    public class AggregateRoot : Entity, IAggregateRoot
+    {
+        private List<INotification> _domainEvents;
+        public IReadOnlyCollection<INotification> DomainEvents => _domainEvents.AsReadOnly();
+
+        public AggregateRoot()
+        {
+            _domainEvents = new List<INotification>();
+        }
+
+        public void RaiseDomainEvent(INotification eventItem)
+        {
+            _domainEvents.Add(eventItem);
+        }
+
+        public void ClearEvents()
+        {
+            _domainEvents.Clear();
+        }
+    }
+}

--- a/Gossip.Domain/Models/Chat/Channel.cs
+++ b/Gossip.Domain/Models/Chat/Channel.cs
@@ -7,14 +7,17 @@ namespace Gossip.Domain.Models.Chat
 {
     public class Channel : Entity, IAggregateRoot
     {
+        private List<Message> _mesasges;
+        
         public string Name { get; set; }
         public string Description { get; set; }
 
-        public List<Message> Messages { get; set; }
+        public IReadOnlyCollection<Message> Messages => _mesasges.AsReadOnly();
 
-        public Channel()
+        public Channel(string name)
         {
-            Messages = new List<Message>();
+            Name = name;
+            _mesasges = new List<Message>();
         }
 
         public bool IsEmpty()
@@ -22,18 +25,9 @@ namespace Gossip.Domain.Models.Chat
             return Messages.Count == 0;
         }
 
-        public void AddMessage(int? parentId, string content)
+        public void AddMessage(string content, int? parentMessageId = null)
         {
-            var parent = parentId != null ? Messages.Single(m => m.Id == parentId) : null;
-
-            Messages.Add(new Message
-            {
-                Content = content,
-                ChannelId = Id,
-                Channel = this,
-                ParentId = parentId,
-                Parent = parent
-            });
+            _mesasges.Add(new Message(content, parentMessageId));
 
             RaiseDomainEvent(new NewMessageCreatedEvent
             {
@@ -41,16 +35,9 @@ namespace Gossip.Domain.Models.Chat
             });
         }
 
-        public void RemoveMessage(int messageId)
+        public void RemoveMessage(Message message)
         {
-            var toBeRemoved = Messages.Single(m => m.Id == messageId);
-
-            if (Messages.Any(m => m.ParentId == messageId))
-            {
-                throw new InvalidOperationException("Message has children");
-            }
-
-            Messages.Remove(toBeRemoved);
+            _mesasges.Remove(message);
         }
     }
 }

--- a/Gossip.Domain/Models/Chat/Channel.cs
+++ b/Gossip.Domain/Models/Chat/Channel.cs
@@ -5,7 +5,7 @@ using Gossip.Domain.Events.Chat;
 
 namespace Gossip.Domain.Models.Chat
 {
-    public class Channel : Entity, IAggregateRoot
+    public class Channel : AggregateRoot, IAggregateRoot
     {
         private List<Message> _mesasges;
         

--- a/Gossip.Domain/Models/Chat/Message.cs
+++ b/Gossip.Domain/Models/Chat/Message.cs
@@ -4,16 +4,13 @@
     {
         public string Content { get; set; }
         public int Likes { get; set; }
+        public int? ParentId { get; }
 
-        public int ChannelId { get; set; }
-        public Channel Channel { get; set; }
-
-        public int? ParentId { get; set; }
-        public Message Parent { get; set; }
-
-        public Message()
+        public Message(string content, int? parentMessageId = null)
         {
+            Content = content;
             Likes = 0;
+            ParentId = parentMessageId;
         }
 
         public void Like()

--- a/Gossip.Domain/Models/Entity.cs
+++ b/Gossip.Domain/Models/Entity.cs
@@ -1,19 +1,7 @@
-﻿using System.Collections.Generic;
-using MediatR;
-
-namespace Gossip.Domain.Models
+﻿namespace Gossip.Domain.Models
 {
     public class Entity : IEntity
     {
-        public int Id { get; set; }
-
-        private List<INotification> _domainEvents;
-        public List<INotification> DomainEvents => _domainEvents;
-
-        public void RaiseDomainEvent(INotification eventItem)
-        {
-            _domainEvents = _domainEvents ?? new List<INotification>();
-            _domainEvents.Add(eventItem);
-        }
+        public int Id { get; }
     }
 }

--- a/Gossip.Domain/Models/IAggregateRoot.cs
+++ b/Gossip.Domain/Models/IAggregateRoot.cs
@@ -1,6 +1,6 @@
 ﻿namespace Gossip.Domain.Models
 {
-    public interface IAggregateRoot
+    public interface IAggregateRoot : IEntity
     {        
     }
 }

--- a/Gossip.Domain/Models/IEntity.cs
+++ b/Gossip.Domain/Models/IEntity.cs
@@ -2,6 +2,6 @@
 {
     public interface IEntity
     {
-        int Id { get; set; }
+        int Id { get; }
     }
 }

--- a/Gossip.Domain/Models/ReadOnly/ActivityReport/ActivitySnapshot.cs
+++ b/Gossip.Domain/Models/ReadOnly/ActivityReport/ActivitySnapshot.cs
@@ -2,5 +2,6 @@
 {
     public class ActivitySnapshot : IAggregateRoot
     {
+        public int Id { get; }
     }
 }

--- a/Gossip.SQLite.Tests/Chat/ChannelsTest.cs
+++ b/Gossip.SQLite.Tests/Chat/ChannelsTest.cs
@@ -62,7 +62,7 @@ namespace Gossip.SQLite.Tests.Chat
                     ctx.Channels.RemoveRange(ctx.Channels);
 
                     // Act
-                    channelRepo.InsertChannel(new Channel {Name = "abc", Description = "def"});
+                    channelRepo.InsertChannel(new Channel("abc") { Description = "def"});
                     var channels = await channelRepo.GetAllChannels();
 
                     // Assert

--- a/Gossip.SQLite/SQLiteMediatorExtension.cs
+++ b/Gossip.SQLite/SQLiteMediatorExtension.cs
@@ -10,7 +10,7 @@ namespace Gossip.SQLite
         public static async Task DispatchDomainEventsAsync(this IMediator mediator, GossipContext ctx)
         {
             var entities = ctx.ChangeTracker
-                .Entries<Entity>()
+                .Entries<AggregateRoot>()
                 .Where(x => x.Entity.DomainEvents != null && x.Entity.DomainEvents.Any())
                 .Select(p => p.Entity);
 


### PR DESCRIPTION
Channel constructor enforces proper state (no nameless channel)
Channel.Messages can not be changed outside Channel (AR)
Reference from Message to Channel not needed in domain model
Reference form Message to Channel by Id not needed
Parent message check dropped for performance reasons (all messaages scanned when message is added), eventual consistency assumed by means of ParentId

Events are handled on AR level
Channel is AR, Message is not
Restrictions on Events collection on AR